### PR TITLE
Update vite-plugin-static-copy to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "consola": "^3.2.3",
     "pathe": "^1.1.2",
     "vite-plugin-externals": "^0.6.2",
-    "vite-plugin-static-copy": "^2.2.0"
+    "vite-plugin-static-copy": "^3.1.4"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.11.2",


### PR DESCRIPTION
https://github.com/sapphi-red/vite-plugin-static-copy/blob/main/CHANGELOG.md

According to this changelog, `vite-plugin-static-copy` migrated from `fast-glob` to `tinyglobby`.  Updated to use the latest version